### PR TITLE
allele frequency scripts

### DIFF
--- a/tools/frq/add_gene.py
+++ b/tools/frq/add_gene.py
@@ -1,0 +1,81 @@
+#!/usr/bin/python
+
+# Example Usage:
+# python add_gene.py --sample_ids T_H_50472 G_H_507472 -o vcftools/all_genes.frq
+
+import pandas as pd
+import argparse
+parser = argparse.ArgumentParser()
+parser.add_argument('-i','--sample_ids', nargs='+', type=str, help='<Required> Set flag, where each sample ID is listed', required=True)
+parser.add_argument('-o', '--outfile',required = True, help="output file", type=str)
+args = parser.parse_args()
+
+def extract_gene_names(info):
+    '''Function to extract gene names from the INFO field. Returns list'''
+    gene_names = []
+    for item in info.split(';'):
+        if item.startswith('ANN='):
+            ann_fields = item.split('|')
+            gene_name = ann_fields[3]
+            gene_names.append(gene_name)
+    return gene_names
+
+df_dict = {}
+
+for sample in args.sample_ids :
+    vcf_file= 'src/{}.vcf'.format(sample) # original vcf
+    file_2 = 'vcftools/{}.frq'.format(sample) # freq table of vcftools
+
+    coord2gene = {}
+    # Read VCF file and extract sample names and gene names
+    with open(vcf_file, 'r') as f:
+        for line in f:
+
+            if line.startswith('#CHROM'):
+                sample_names = line.strip().split('\t')[9:]
+            elif not line.startswith('#'):
+                fields = line.strip().split('\t')
+                chrom_col= fields[0]
+                pos_col = fields[1]
+                info_col = fields[7]
+                gene_names_per_sample = extract_gene_names(info_col)
+                assert len(gene_names_per_sample)==1, 'Found more than 1 gene for a row'
+
+                # save to look up table
+                assert chrom_col+'_'+pos_col not in coord2gene, 'not unique key {} {}'.format(chrom_col, pos_col)
+                coord2gene[chrom_col+'_'+pos_col]= gene_names_per_sample
+
+    # add in gene col to output of vcftools
+    df2= pd.read_csv(file_2, sep='\t')
+
+    # handle for if ran vcftools with --freq2 then will add a 6th unnamed col
+    if df2.index[0].startswith('chr'):
+        new_cols = list(df2.columns)+['DETAILS']
+        chrom_col = list(df2.index)
+        df2.insert(0, 'a', chrom_col)
+        df2 = df2.reset_index(drop=True)
+        df2.columns= new_cols
+
+    # create list of values for each row
+    gene_col = []
+    for i in range(0, df2.shape[0]):
+        key = df2['CHROM'][i]+'_'+str(df2['POS'][i])
+        gene= coord2gene[key][0]
+        gene_col.append(gene)
+    # add col
+    df2['GENE']= gene_col
+
+    # specific to single sample per vcf
+    df2['SAMPLE']=[sample]*df2.shape[0]
+
+    df_dict[sample]=df2
+
+# now merge 2 df into one
+n = 0
+for v in df_dict.values():
+    if n==0:
+        merged_df = v
+        n=1
+    else:
+        merged_df = pd.concat([merged_df,v],  ignore_index=True)
+merged_df.to_csv(args.outfile, sep='\t', index=False)

--- a/tools/frq/allele_frq.sh
+++ b/tools/frq/allele_frq.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/bash
+
+# Example usage:
+# bash allele_frq.sh src/G_H_507472.vcf vcftools/G_H_507472
+# bash allele_frq.sh src/T_H_50472.vcf vcftools/T_H_50472
+
+VCF=${1}
+OUT=${2}
+
+# Allele freq. exclude sites with more than 2 alleles
+echo 'Running allele freq'
+vcftools --gzvcf $VCF --freq2 --out $OUT --max-alleles 2

--- a/tools/frq/frq_plots.R
+++ b/tools/frq/frq_plots.R
@@ -1,0 +1,101 @@
+#!/usr/bin/Rscript
+
+### Example Usage:
+# Rscript frq_plots.R -s G_H_507472 -frq vcftools/all_genes.frq -t 2000
+# Rscript frq_plots.R -s T_H_50472 -frq vcftools/all_genes.frq -t 2000
+
+# Rscript frq_plots.R -s G_H_507472 -frq vcftools/all_genes.frq -t 1000
+# Rscript frq_plots.R -s T_H_50472 -frq vcftools/all_genes.frq -t 1000
+
+# Rscript frq_plots.R -s G_H_507472 -frq vcftools/all_genes.frq -t 4000
+# Rscript frq_plots.R -s T_H_50472 -frq vcftools/all_genes.frq -t 4000
+###
+
+# TODO update so accepts list of single_sample and loop through "per sample plots" for each sample
+  # currently the "all sample plots" are redundant
+
+suppressPackageStartupMessages(library("data.table"))
+suppressPackageStartupMessages(library("tidyverse"))
+suppressPackageStartupMessages(library("ggplot2"))
+suppressPackageStartupMessages(library("argparse"))
+
+parser <- ArgumentParser()
+parser$add_argument("-s", "--single_sample", type='character', help="single sample ID")
+parser$add_argument("-frq", "--frq_data", type='character', help='allele freq containing all samples')
+parser$add_argument('-t', '--threshold',  type='integer', help='threshold of allele freq')
+args <- parser$parse_args()
+
+###
+# Per sample plots
+###
+# 1. phred encoded site quality (how much confidence have in variant calls)
+var_qual = fread(paste('vcftools/', args$single_sample, '.lqual', sep=''))
+a <- ggplot(var_qual, aes(QUAL)) + geom_density(fill = "dodgerblue1", colour = "black", alpha = 0.3) +
+  theme_light()
+pdf(paste('sitequal_', args$single_sample,'.pdf',sep=''))
+a
+dev.off()
+# unique(var_qual$QUAL)
+
+# 2. variant mean depth (n reads mapped to each position)
+var_depth = fread(paste('vcftools/', args$single_sample, '.ldepth.mean', sep=''))
+a <- ggplot(var_depth, aes(MEAN_DEPTH)) + geom_density(fill = "dodgerblue1", colour = "black", alpha = 0.3) +
+  theme_light()
+pdf(paste('vardepth_', args$single_sample,'.pdf',sep=''))
+a
+dev.off()
+# tab = summary(var_depth$MEAN_DEPTH)
+
+###
+# all sample plots
+###
+# gene cts for all
+df = fread(args$frq_data) %>% as.data.frame()
+df = df %>%
+  arrange(CHROM, POS)
+
+# freq of all
+pdf('gene_freq.pdf')
+a = ggplot(df, aes(x=GENE, color=SAMPLE, fill =SAMPLE)) +
+  geom_bar() +
+  theme(
+    axis.text.x = element_blank(),
+    axis.ticks.x = element_blank(),
+  ) +
+  labs(title='Gene Frequency (All)', x='Gene', y='Count')
+a
+dev.off()
+
+# freq of all split by chrom
+pdf('gene_freq_byCHROM.pdf')
+a+ facet_grid(CHROM ~ .)
+dev.off()
+
+
+# top only (based on combined occurance in all samples)
+frq_df = as.data.frame(table(df$GENE) )
+colnames(frq_df)= c('GENE', 'Freq')
+frq_df = frq_df[order(frq_df$Freq, decreasing = TRUE), ]
+row.names(frq_df)= NULL
+# filter based on threshold (occurance)
+frq_df = frq_df[frq_df$Freq>args$threshold,]
+genes = frq_df$GENE %>% as.vector()
+
+# filter orig dataframe for these genes
+s1 = subset(df, GENE %in% genes)
+
+# freq of all
+pdf(paste('gene_freq_top_',args$threshold,'.pdf',sep=''))
+a = ggplot(s1, aes(x=GENE, color=SAMPLE, fill =SAMPLE)) +
+  geom_bar() +
+  theme(axis.text.x = element_text(angle = 90))+
+  labs(title=paste('Top Gene Frequency (>=',args$threshold, ' Freq)',sep=''), x='Gene', y='Count')
+a
+dev.off()
+
+# freq of all split by chrom
+pdf(paste('gene_freq_byCHROM_top_', args$threshold, '.pdf', sep=''))
+a +
+  facet_grid(CHROM ~ .) +
+  theme(axis.text.x = element_text(angle = 90))
+dev.off()

--- a/tools/frq/wrapper.sh
+++ b/tools/frq/wrapper.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/bash
+
+# Get allele freq
+bash allele_frq.sh src/G_H_507472.vcf vcftools/G_H_507472
+bash allele_frq.sh src/T_H_50472.vcf vcftools/T_H_50472
+
+# Add gene symbol info
+python add_gene.py --sample_ids T_H_50472 G_H_507472 -o vcftools/all_genes.frq
+
+# Generate plots
+Rscript frq_plots.R -s G_H_507472 -frq vcftools/all_genes.frq -t 2000
+Rscript frq_plots.R -s T_H_50472 -frq vcftools/all_genes.frq -t 2000
+
+Rscript frq_plots.R -s G_H_507472 -frq vcftools/all_genes.frq -t 1000
+Rscript frq_plots.R -s T_H_50472 -frq vcftools/all_genes.frq -t 1000
+
+Rscript frq_plots.R -s G_H_507472 -frq vcftools/all_genes.frq -t 4000
+Rscript frq_plots.R -s T_H_50472 -frq vcftools/all_genes.frq -t 4000


### PR DESCRIPTION
see `tools/frq/wrapper.sh`. series of scripts to extract allele freq and gene names from vcf files. additional script to visualize results.

requires:
+ single sample per input vcf

next steps:
+ will require reformatting to nextflow, currently written as a wrapper script
+ update figure script to accept list of single_sample and loop through "per sample plots" for each sample, currently the "all sample plots" are redundant