### PR TITLE
update mark_duplicates and bwamem

### DIFF
--- a/tools/bwa/bwamem2.nf
+++ b/tools/bwa/bwamem2.nf
@@ -13,16 +13,14 @@ process bwaMem2Alignment {
     path trim_read1
     path trim_read2
     path idx
-    val id 
-
 
     output:
-    file("${trim_read1.baseName}.bam")
+    file("${trim_read1.simpleName}.bam")
 
     // BWA-MEM2 alignment command
     script:
     """
-    bwa-mem2 mem -K 100000000 -t 6 -Y -M -R "@RG\tID:${params.id}\tLB:no_library\tPL:illumina\tPU:none\tSM:${trim_read1.baseName}" ${params.idx} ${trim_read1} ${trim_read2} | samtools view -Sb -@ 4 > ${trim_read1.baseName}.bam
+    bwa-mem2 mem -K 100000000 -t 6 -Y -M -R "@RG\\tID:${params.ID}\\tLB:no_library\\tPL:illumina\\tPU:none\\tSM:${trim_read1.simpleName}" ${params.idx} ${trim_read1} ${trim_read2} | samtools view -Sb -@ 4 > ${trim_read1.simpleName}.bam
     """
 }
 

--- a/tools/gatk/mark_duplicates.nf
+++ b/tools/gatk/mark_duplicates.nf
@@ -16,17 +16,16 @@ process MarkDuplicates {
 
     script:
     """
-    gatk MarkDuplicates \
-        -I ${tumor_bam_sorted} \
+    gatk MarkDuplicates -I ${tumor_bam_sorted} \
         -O ${tumor_bam_sorted.baseName}_marked_duplicates.bam \
         -M ${tumor_bam_sorted.baseName}_marked_duplicates_metrics.txt \
         --VALIDATION_STRINGENCY LENIENT
 
-   gatk MarkDuplicates \ 
-        -I ${normal_bam_sorted} \
+   gatk MarkDuplicates -I ${normal_bam_sorted} \
         -O ${normal_bam_sorted.baseName}_marked_duplicates.bam \
         -M ${normal_bam_sorted.baseName}_marked_duplicates_metrics.txt \
         --VALIDATION_STRINGENCY LENIENT
     """
 
 }
+

--- a/workflows/bwa/bwamem2.nf
+++ b/workflows/bwa/bwamem2.nf
@@ -5,5 +5,5 @@ include { bwaMem2Alignment } from '../../tools/bwa/bwamem2.nf'
 // Define the workflow
 workflow {
     // Run BWA-MEM2 alignment for each read file
-    bwaMem2Alignment(file(params.trim_read1), file(params.trim_read2), file(params.idx), "test")
+    bwaMem2Alignment(file(params.trim_read1), file(params.trim_read2), file(params.idx))
 }

--- a/workflows/gatk/mark_duplicates.nf
+++ b/workflows/gatk/mark_duplicates.nf
@@ -5,6 +5,6 @@ include {MarkDuplicates} from '../../tools/gatk/mark_duplicates.nf'
 //Define workflow for marking duplicates
 workflow {
 
-    MarkDuplicates (file(params.tumor_bam_sorted), file(params.normal_bam_sorted), "test")
+    MarkDuplicates(file(params.tumor_bam_sorted), file(params.normal_bam_sorted), "test")
 
 }


### PR DESCRIPTION
- added \\t delimiter to bwamem and changed basename to simplename for cleaner filename output
- edited syntax of mark duplicates script to avoid nextflow parsing "-I" argument as a command
