### PR TITLE
calc contamination and get pileup summaries 

### DIFF
--- a/tools/gatk/calculate_contamination.nf
+++ b/tools/gatk/calculate_contamination.nf
@@ -12,16 +12,19 @@ process CalculateContamination {
     input:
     path tumor_pileups_table
     path normal_pileups_table
+    val ID
 
     output:
-    path("${tumor_pileups_table.baseName"}_contamination_table)
-    path("${tumor_pileups_table.baseName"}_segmentation_table)
+    path("${tumor_pileups_table.baseName}_contamination_table")
+    path("${tumor_pileups_table.baseName}_segmentation_table")
 
   // calculatContamination command
     script:
     """
-        gatk4 CalculateContamination \\
+        gatk CalculateContamination \\
         -I ${tumor_pileups_table} \\
         --matched ${normal_pileups_table} \\
         -O ${tumor_pileups_table.baseName}_contamination_table \\
         -tumor-segmentation ${tumor_pileups_table.baseName}_segmentation_table
+    """
+}

--- a/tools/gatk/get_pileup_summaries.nf
+++ b/tools/gatk/get_pileup_summaries.nf
@@ -11,6 +11,7 @@ process GetPileupSummaries {
     path tumor_bam_sorted
     path normal_bam_sorted
     path exac
+    val ID
 
     output:
     file("${tumor_bam_sorted.baseName}.getpileupsummaries.table")

--- a/tools/gatk/get_pileup_summaries.nf
+++ b/tools/gatk/get_pileup_summaries.nf
@@ -20,14 +20,14 @@ process GetPileupSummaries {
     """
     gatk GetPileupSummaries \\
     -I ${tumor_bam_sorted} \\
-    -V ${exac} \\
-    -L ${exac} \\
+    -V ${params.exac} \\
+    -L ${params.exac} \\
     -O ${tumor_bam_sorted.baseName}.getpileupsummaries.table
 
     gatk GetPileupSummaries \\
     -I ${normal_bam_sorted} \\
-    -V ${exac} \\
-    -L ${exac} \\
+    -V ${params.exac} \\
+    -L ${params.exac} \\
     -O ${normal_bam_sorted.baseName}.getpileupsummaries.table
     """
 }

--- a/tools/gatk/get_pileup_summaries.nf
+++ b/tools/gatk/get_pileup_summaries.nf
@@ -18,14 +18,12 @@ process GetPileupSummaries {
     file("${normal_bam_sorted.baseName}.getpileupsummaries.table")
     script:
     """
-    //script for tumor_bam
     gatk GetPileupSummaries \\
     -I ${tumor_bam_sorted} \\
     -V ${exac} \\
     -L ${exac} \\
     -O ${tumor_bam_sorted.baseName}.getpileupsummaries.table
 
-    //script for normal_bam
     gatk GetPileupSummaries \\
     -I ${normal_bam_sorted} \\
     -V ${exac} \\

--- a/tools/gatk/learn_read_orientation_model.nf
+++ b/tools/gatk/learn_read_orientation_model.nf
@@ -9,6 +9,7 @@ process LearnReadOrientationModel {
 
     input: // if multiple tumor samples are being processed, only a single f1r2_tar_gz output is necessary, which will contain info for all included samples
     path f1r2_tar_gz
+    val ID
 
     output:
     path "read_orientation_model.tar.gz"

--- a/workflows/gatk/calculation_contamination.nf
+++ b/workflows/gatk/calculation_contamination.nf
@@ -1,9 +1,9 @@
 #!/usr/bin/env nextflow
 
-include {CalculateContamination} from '../tools/gatk/calculate_contamination.nf'
+include {CalculateContamination} from '../../tools/gatk/calculate_contamination.nf'
 
 // Define the workflow for calculating contamination
 workflow {
 
-    bwaMem2Alignment(file(params.tumor_pileup_table), file(params.normal_pileups_table), "test")
+    CalculateContamination(file(params.tumor_pileups_table), file(params.normal_pileups_table), "test")
 }

--- a/workflows/gatk/get_pileup_summaries.nf
+++ b/workflows/gatk/get_pileup_summaries.nf
@@ -1,9 +1,9 @@
 #!/usr/bin/env nextflow
 
-include {GetPileupSummaries} from '../tools/gatk/get_pileup_summaries.nf'
+include {GetPileupSummaries} from '../../tools/gatk/get_pileup_summaries.nf'
 
 // Define the workflow for get pileup summaries
 workflow {
     
-    GetPileupSummaries(file(params.tumor_bam),file(params.normal_bam),file(params.exac), "test")
+    GetPileupSummaries(file(params.tumor_bam), file(params.normal_bam), file(params.exac), "test")
 }

--- a/workflows/gatk/get_pileup_summaries.nf
+++ b/workflows/gatk/get_pileup_summaries.nf
@@ -5,5 +5,5 @@ include {GetPileupSummaries} from '../../tools/gatk/get_pileup_summaries.nf'
 // Define the workflow for get pileup summaries
 workflow {
     
-    GetPileupSummaries(file(params.tumor_bam), file(params.normal_bam), file(params.exac), "test")
+    GetPileupSummaries(file(params.tumor_bam_sorted), file(params.normal_bam_sorted), file(params.exac), "test")
 }

--- a/workflows/gatk/learn_read_orientation_model.nf
+++ b/workflows/gatk/learn_read_orientation_model.nf
@@ -1,6 +1,6 @@
 #!/usr/bin/env nextflow
 
-include {LearnReadOrientationModel} from '../tools/gatk/learn_read_orientation_model.nf'
+include {LearnReadOrientationModel} from '../../tools/gatk/learn_read_orientation_model.nf'
 
 //Define workflow for learn read orientation model
 


### PR DESCRIPTION
- fixed relative paths referring to tool location in dir
- removed comment that was inside script quotes

I don't know exactly why, but when using programs that automatically find index files from the path of a reference file, nextflow runs fine if this is referenced straight from the params file (variable is params.exac) but isn't able to locate that path correctly when you define it in the input (variable is exac). 