### PR TITLE
update gatk dockerfile

### DIFF
--- a/tools/gatk/Dockerfile
+++ b/tools/gatk/Dockerfile
@@ -8,7 +8,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
         && apt-get install -y \
                 build-essential \
-                openjdk-8-jre-headless \
+                openjdk-11-jre-headless \
                 r-base \
                 unzip \
                 wget \

--- a/tools/gatk/Dockerfile
+++ b/tools/gatk/Dockerfile
@@ -8,7 +8,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
         && apt-get install -y \
                 build-essential \
-                openjdk-11-jre-headless \
+                openjdk-17-jre-headless \
                 r-base \
                 unzip \
                 wget \

--- a/tools/gatk/Dockerfile
+++ b/tools/gatk/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
                 r-base \
                 unzip \
                 wget \
+                python \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
- update openjdk from 8 to 17 due to java error where `org/broadinstitute/hellbender/Main has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 52.0`
- add python to installs