### PR TITLE
sliced fastq test files

### DIFF
--- a/tools/bcftools/vcf_sort_index_normalize.nf
+++ b/tools/bcftools/vcf_sort_index_normalize.nf
@@ -1,6 +1,6 @@
 #!/usr/bin/env nextflow
 
-process vcfSortIndexNormalize {
+process VcfSortIndexNormalize {
     // Set output directory
     publishDir "${params.outdir}/svc/sort_index", mode: 'copy'
 

--- a/tools/gatk/get_pileup_summaries.nf
+++ b/tools/gatk/get_pileup_summaries.nf
@@ -14,20 +14,20 @@ process GetPileupSummaries {
     val ID
 
     output:
-    file("${tumor_bam_sorted.baseName}.getpileupsummaries.table")
-    file("${normal_bam_sorted.baseName}.getpileupsummaries.table")
+    file("${tumor_bam_sorted.simpleName}.getpileupsummaries.table")
+    file("${normal_bam_sorted.simpleName}.getpileupsummaries.table")
     script:
     """
     gatk GetPileupSummaries \\
     -I ${tumor_bam_sorted} \\
     -V ${params.exac} \\
     -L ${params.exac} \\
-    -O ${tumor_bam_sorted.baseName}.getpileupsummaries.table
+    -O ${tumor_bam_sorted.simpleName}.getpileupsummaries.table
 
     gatk GetPileupSummaries \\
     -I ${normal_bam_sorted} \\
     -V ${params.exac} \\
     -L ${params.exac} \\
-    -O ${normal_bam_sorted.baseName}.getpileupsummaries.table
+    -O ${normal_bam_sorted.simpleName}.getpileupsummaries.table
     """
 }

--- a/tools/mutect/filter_mutect.nf
+++ b/tools/mutect/filter_mutect.nf
@@ -17,6 +17,7 @@ process FilterMutectCalls {
     path read_orientation_model
     path segmentation_table
     path contamination_table
+    val ID
 
     output:
     file("${unfiltered_vcf.baseName}_filtered.vcf")

--- a/tools/mutect/mutect.nf
+++ b/tools/mutect/mutect.nf
@@ -1,7 +1,7 @@
 #!/usr/bin/env nextflow
 
 // Define the process for running MuTect2
-process mutect2 {
+process Mutect2 {
     // Set maximum memory
     memory '40 GB'
 

--- a/tools/mutect/mutect.nf
+++ b/tools/mutect/mutect.nf
@@ -15,6 +15,7 @@ process mutect2 {
     path mutect_idx
     path pon
     path gnomad
+    val ID
 
     output:
     path "${tumor_bam.simpleName}_unfiltered.vcf"
@@ -25,13 +26,12 @@ process mutect2 {
     script:
     """
     gatk Mutect2 \
-        -R ${idx} \
-        -I ${tumor_bam_sorted} \
-        -I ${normal_bam_sorted} \
+        -R ${params.mutect_idx} \
+        -I ${tumor_bam} \
+        -I ${normal_bam} \
         --panel-of-normals ${pon} \
         --germline-resource ${gnomad} \
-        -O ${tumor_bam_sorted.simpleName}_unfiltered.vcf \
-        --f1r2-tar-gz ${tumor_bam_sorted.simpleName}_f1r2.tar.gz \
-        -stats ${tumor_bam.simpleName}_unfiltered.vcf.stats
+        -O ${tumor_bam.simpleName}_unfiltered.vcf \
+        --f1r2-tar-gz ${tumor_bam.simpleName}_f1r2.tar.gz
     """
 }

--- a/tools/mutect/mutect.nf
+++ b/tools/mutect/mutect.nf
@@ -10,28 +10,28 @@ process mutect2 {
 
     // Define input and output
     input:
-    path tumor_bam
-    path normal_bam
+    path tumor_bam_sorted
+    path normal_bam_sorted
     path mutect_idx
     path pon
     path gnomad
     val ID
 
     output:
-    path "${tumor_bam.simpleName}_unfiltered.vcf"
-    path "${tumor_bam.simpleName}_unfiltered.vcf.stats"
-    path "${tumor_bam.simpleName}_f1r2.tar.gz"
+    path "${tumor_bam_sorted.simpleName}_unfiltered.vcf"
+    path "${tumor_bam_sorted.simpleName}_unfiltered.vcf.stats"
+    path "${tumor_bam_sorted.simpleName}_f1r2.tar.gz"
 
     // MuTect2 command
     script:
     """
     gatk Mutect2 \
         -R ${params.mutect_idx} \
-        -I ${tumor_bam} \
-        -I ${normal_bam} \
+        -I ${tumor_bam_sorted} \
+        -I ${normal_bam_sorted} \
         --panel-of-normals ${params.pon} \
         --germline-resource ${params.gnomad} \
-        -O ${tumor_bam.simpleName}_unfiltered.vcf \
-        --f1r2-tar-gz ${tumor_bam.simpleName}_f1r2.tar.gz
+        -O ${tumor_bam_sorted.simpleName}_unfiltered.vcf \
+        --f1r2-tar-gz ${tumor_bam_sorted.simpleName}_f1r2.tar.gz
     """
 }

--- a/tools/mutect/mutect.nf
+++ b/tools/mutect/mutect.nf
@@ -1,5 +1,4 @@
 #!/usr/bin/env nextflow
-nextflow.enable.dsl = 2
 
 // Define the process for running MuTect2
 process mutect2 {
@@ -11,28 +10,28 @@ process mutect2 {
 
     // Define input and output
     input:
-    path tumor_bam_sorted
-    path normal_bam_sorted
+    path tumor_bam
+    path normal_bam
     path mutect_idx
     path pon
     path gnomad
 
     output:
-    path "${tumor_bam.baseName}_unfiltered.vcf"
-    path "${tumor_bam.baseName}_unfiltered.vcf.stats"
-    path "${tumor_bam.baseName}_f1r2.tar.gz"
+    path "${tumor_bam.simpleName}_unfiltered.vcf"
+    path "${tumor_bam.simpleName}_unfiltered.vcf.stats"
+    path "${tumor_bam.simpleName}_f1r2.tar.gz"
 
     // MuTect2 command
     script:
     """
     gatk Mutect2 \
-        -R ${mutect_idx} \
+        -R ${idx} \
         -I ${tumor_bam_sorted} \
         -I ${normal_bam_sorted} \
         --panel-of-normals ${pon} \
         --germline-resource ${gnomad} \
-        -O ${tumor_bam_sorted.baseName}_unfiltered.vcf \
-        --f1r2-tar-gz ${tumor_bam_sorted.baseName}_f1r2.tar.gz \
-        -stats ${tumor_bam.baseName}_unfiltered.vcf.stats
+        -O ${tumor_bam_sorted.simpleName}_unfiltered.vcf \
+        --f1r2-tar-gz ${tumor_bam_sorted.simpleName}_f1r2.tar.gz \
+        -stats ${tumor_bam.simpleName}_unfiltered.vcf.stats
     """
 }

--- a/tools/mutect/mutect.nf
+++ b/tools/mutect/mutect.nf
@@ -29,8 +29,8 @@ process mutect2 {
         -R ${params.mutect_idx} \
         -I ${tumor_bam} \
         -I ${normal_bam} \
-        --panel-of-normals ${pon} \
-        --germline-resource ${gnomad} \
+        --panel-of-normals ${params.pon} \
+        --germline-resource ${params.gnomad} \
         -O ${tumor_bam.simpleName}_unfiltered.vcf \
         --f1r2-tar-gz ${tumor_bam.simpleName}_f1r2.tar.gz
     """

--- a/tools/qc/fastqc/fastqc.nf
+++ b/tools/qc/fastqc/fastqc.nf
@@ -1,7 +1,7 @@
 #!/usr/bin/env nextflow
 
 // Define the process for running FastQC
-process fastQC {
+process FastQC {
     publishDir "${params.outdir}/fastqc", mode: 'copy'
 
     input:

--- a/tools/qc/fastqc/trim_fastqc.nf
+++ b/tools/qc/fastqc/trim_fastqc.nf
@@ -1,7 +1,7 @@
 #!/usr/bin/env nextflow
 
 // Define the process for running FastQC
-process fastQC {
+process FastQC {
     publishDir "${params.outdir}/trimfastqc", mode: 'copy'
 
     input:

--- a/tools/qc/multiqc/multiqc.nf
+++ b/tools/qc/multiqc/multiqc.nf
@@ -1,7 +1,7 @@
 #!/usr/bin/env nextflow
 
 //Define process for multiQC
-process multiQC {
+process MultiQC {
     // Set output directory for multiQC results
     publishDir "${params.outdir}/multiqc", mode: 'copy'
 

--- a/tools/samtools/sort_and_index.nf
+++ b/tools/samtools/sort_and_index.nf
@@ -1,6 +1,6 @@
 #!/usr/bin/env nextflow
 
-process sortAndIndex {
+process SortAndIndex {
     // Set maximum memory
     memory '40 GB'
 

--- a/tools/samtools/sort_marked_duplicates.nf
+++ b/tools/samtools/sort_marked_duplicates.nf
@@ -9,10 +9,12 @@ process SortMarkedDuplicates {
 
     output: 
     file("${bam_duplicates_unsorted.baseName}_sorted.bam")
+    file("${bam_duplicates_unsorted.baseName}_sorted.bam.bai")
 
 
     script:
     """
     samtools sort ${bam_duplicates_unsorted} > ${bam_duplicates_unsorted.baseName}_sorted.bam
+    samtools index ${bam_duplicates_unsorted.baseName}_sorted.bam > ${bam_duplicates_unsorted.baseName}_sorted.bam.bai
     """
 }

--- a/tools/snpeff/annotate_variants.nf
+++ b/tools/snpeff/annotate_variants.nf
@@ -1,6 +1,6 @@
 #!/usr/bin/env nextflow
 
-process Annotate_Variants {
+process AnnotateVariants {
     publishDir "${params.outdir}/svc/annotated_variants", mode: 'copy'
     // Set maximum memory
     memory '40 GB'

--- a/tools/trimmomatic/trimmomatic.nf
+++ b/tools/trimmomatic/trimmomatic.nf
@@ -1,6 +1,6 @@
 #!/usr/bin/env nextflow
 
-process trimmomaticPE {
+process TrimmomaticPE {
     // Set maximum memory
     memory '40 GB'
 

--- a/workflows/bcftools/vcf_sort_index_normalize.nf
+++ b/workflows/bcftools/vcf_sort_index_normalize.nf
@@ -1,9 +1,9 @@
 #!/usr/bin/env nextflow
 
-include {vcfSortIndexNormalize} from '../../tools/bcftools/vcf_sort_index_normalize.nf'
+include {VcfSortIndexNormalize} from '../../tools/bcftools/vcf_sort_index_normalize.nf'
 
 // Define the workflow
 workflow {
     // Run vcfSortIndexNormalize 
-    vcfSortIndexNormalize(file(params.unfiltered_vcf), params.ID)
+    VcfSortIndexNormalize(file(params.unfiltered_vcf), params.ID)
 }

--- a/workflows/bcftools/vcf_sort_index_normalize.nf
+++ b/workflows/bcftools/vcf_sort_index_normalize.nf
@@ -5,5 +5,5 @@ include {vcfSortIndexNormalize} from '../../tools/bcftools/vcf_sort_index_normal
 // Define the workflow
 workflow {
     // Run vcfSortIndexNormalize 
-    vcfSortIndexNormalize(file(params.unfiltered_vcf), "test")
+    vcfSortIndexNormalize(file(params.unfiltered_vcf), params.ID)
 }

--- a/workflows/gatk/calculation_contamination.nf
+++ b/workflows/gatk/calculation_contamination.nf
@@ -5,5 +5,5 @@ include {CalculateContamination} from '../../tools/gatk/calculate_contamination.
 // Define the workflow for calculating contamination
 workflow {
 
-    CalculateContamination(file(params.tumor_pileups_table), file(params.normal_pileups_table), "test")
+    CalculateContamination(file(params.tumor_pileups_table), file(params.normal_pileups_table), params.ID)
 }

--- a/workflows/gatk/get_pileup_summaries.nf
+++ b/workflows/gatk/get_pileup_summaries.nf
@@ -5,5 +5,5 @@ include {GetPileupSummaries} from '../../tools/gatk/get_pileup_summaries.nf'
 // Define the workflow for get pileup summaries
 workflow {
     
-    GetPileupSummaries(file(params.tumor_bam_sorted), file(params.normal_bam_sorted), file(params.exac), "test")
+    GetPileupSummaries(file(params.tumor_bam_sorted), file(params.normal_bam_sorted), file(params.exac), params.ID)
 }

--- a/workflows/gatk/learn_read_orientation_model.nf
+++ b/workflows/gatk/learn_read_orientation_model.nf
@@ -6,6 +6,6 @@ include {LearnReadOrientationModel} from '../../tools/gatk/learn_read_orientatio
 
 workflow { 
 
-	LearnReadOrientationModel (file(params.f1r2_tar_gz), "test")
+	LearnReadOrientationModel (file(params.f1r2_tar_gz), params.ID)
 
   }

--- a/workflows/mutect/filter_mutect.nf
+++ b/workflows/mutect/filter_mutect.nf
@@ -1,9 +1,9 @@
 #!/usr/bin/env nextflow
 
-include {FilterMutectCalls} from '../tools/mutect/filter_mutect.nf
+include {FilterMutectCalls} from '../../tools/mutect/filter_mutect.nf'
 
 // define workflow
 workflow {
     // run the FilterMutectCalls process
-    FilterMutectCalls(file(params.unfiltered_vcf),file(params.mutect_idx),file(params.mutect_idx_fai), file(params.mutect_dict), file(params.vcf_stats), "test")
+    FilterMutectCalls(file(params.unfiltered_vcf),file(params.mutect_idx),file(params.mutect_idx_fai), file(params.mutect_dict), file(params.vcf_stats), file(params.read_orientation_model), file(params.segmentation_table), file(params.contamination_table), params.ID)
 }

--- a/workflows/mutect/mutect2.nf
+++ b/workflows/mutect/mutect2.nf
@@ -4,5 +4,5 @@ include {mutect2} from '../../tools/mutect/mutect.nf'
 
 workflow {
     // Run Mutect2
-    mutect2(file(params.tumor_bam) ,file(params.normal_bam), file(params.mutect_idx), file(params.pon), file(params.gnomad), params.ID)
+    mutect2(file(params.tumor_bam_sorted) ,file(params.normal_bam_sorted), file(params.mutect_idx), file(params.pon), file(params.gnomad), params.ID)
 }

--- a/workflows/mutect/mutect2.nf
+++ b/workflows/mutect/mutect2.nf
@@ -1,6 +1,6 @@
 #!/usr/bin/env nextflow
 
-include {mutect2} from '../tools/mutect/mutect2.nf'
+include {mutect2} from '../../tools/mutect/mutect.nf'
 
 workflow {
     // Run Mutect2

--- a/workflows/mutect/mutect2.nf
+++ b/workflows/mutect/mutect2.nf
@@ -4,5 +4,5 @@ include {mutect2} from '../../tools/mutect/mutect.nf'
 
 workflow {
     // Run Mutect2
-    mutect2(file(params.tumor_bam) ,file(params.normal_bam), file(params.idx), file(params.pon), file(params.gnomad), params.ID)
+    mutect2(file(params.tumor_bam) ,file(params.normal_bam), file(params.mutect_idx), file(params.pon), file(params.gnomad), params.ID)
 }

--- a/workflows/mutect/mutect2.nf
+++ b/workflows/mutect/mutect2.nf
@@ -1,8 +1,8 @@
 #!/usr/bin/env nextflow
 
-include {mutect2} from '../../tools/mutect/mutect.nf'
+include {Mutect2} from '../../tools/mutect/mutect.nf'
 
 workflow {
     // Run Mutect2
-    mutect2(file(params.tumor_bam_sorted) ,file(params.normal_bam_sorted), file(params.mutect_idx), file(params.pon), file(params.gnomad), params.ID)
+    Mutect2(file(params.tumor_bam_sorted) ,file(params.normal_bam_sorted), file(params.mutect_idx), file(params.pon), file(params.gnomad), params.ID)
 }

--- a/workflows/qc/fastqc.nf
+++ b/workflows/qc/fastqc.nf
@@ -1,10 +1,10 @@
 #!/usr/bin/env nextflow
 
-include {fastQC} from '../../tools/qc/fastqc/fastqc.nf'
+include {FastQC} from '../../tools/qc/fastqc/fastqc.nf'
 
 // Define the workflow for fastqc
 
 workflow {
 
-    fastQC(file(params.read1), file(params.read2), params.ID)
+    FastQC(file(params.read1), file(params.read2), params.ID)
 }

--- a/workflows/qc/multiqc.nf
+++ b/workflows/qc/multiqc.nf
@@ -1,9 +1,9 @@
 #!/usr/bin/env nextflow
 
-include {multiQC} from '../../tools/qc/multiqc/multiqc.nf'
+include {MultiQC} from '../../tools/qc/multiqc/multiqc.nf'
 
 // Define the workflow for multiqc
 workflow {
 
-    multiQC(file(params.fastqc_read1), file(params.fastqc_read2), file(params.trim_fastqc_read1), file(params.trim_fastqc_read2), params.ID)
+    MultiQC(file(params.fastqc_read1), file(params.fastqc_read2), file(params.trim_fastqc_read1), file(params.trim_fastqc_read2), params.ID)
 }

--- a/workflows/samtools/sort_and_index.nf
+++ b/workflows/samtools/sort_and_index.nf
@@ -1,11 +1,11 @@
 #!/usr/bin/env nextflow
 
-include {sortAndIndex} from '../../tools/samtools/sort_and_index.nf'
+include {SortAndIndex} from '../../tools/samtools/sort_and_index.nf'
 
 // Define the workflow for sort and index
 workflow { 
 
     //run sortAndIndex
-    sortAndIndex (file(params.bam_unsorted), "test")
+    SortAndIndex (file(params.bam_unsorted), "test")
 
 }

--- a/workflows/snpeff/annotate_variants.nf
+++ b/workflows/snpeff/annotate_variants.nf
@@ -1,10 +1,10 @@
 #!/usr/bin/env nextflow
 
-include {Annotate_Variants} from '../../tools/snpeff/annotate_variants.nf'
+include {AnnotateVariants} from '../../tools/snpeff/annotate_variants.nf'
 
 // Define the workflow for annotating variants
 workflow {
 
-    Annotate_Variants (file(params.filtered_vcf), params.ID)
+    AnnotateVariants (file(params.filtered_vcf), params.ID)
 
 }

--- a/workflows/snpeff/annotate_variants.nf
+++ b/workflows/snpeff/annotate_variants.nf
@@ -5,6 +5,6 @@ include {Annotate_Variants} from '../../tools/snpeff/annotate_variants.nf'
 // Define the workflow for annotating variants
 workflow {
 
-    Annotate_Variants (file(params.filtered_vcf), "test")
+    Annotate_Variants (file(params.filtered_vcf), params.ID)
 
 }

--- a/workflows/trimmomatic/trimmomatic.nf
+++ b/workflows/trimmomatic/trimmomatic.nf
@@ -1,9 +1,9 @@
 #!/usr/bin/env nextflow
 
-include {trimmomaticPE} from '../../tools/trimmomatic/trimmomatic.nf'
+include {TrimmomaticPE} from '../../tools/trimmomatic/trimmomatic.nf'
 
 // define the workflow for trimmomaticPE
 workflow {
    
-    trimmomaticPE (file(params.read1), file(params.read2), file(params.truseq3pefile), "test")
+    TrimmomaticPE (file(params.read1), file(params.read2), file(params.truseq3pefile), "test")
 }


### PR DESCRIPTION
changes made during test run-through using singularity containers and sliced fastq files (200 records).

- updated variable names for consistency during test run through
- add params.ID
- added missing indexing step after samtools sort on marked duplicate file

notes: 
- I did not split and run chroms in parallel with mutect2, but these test files have several chromosomes including UNK, so they could be a good test for that part of the pipeline as well.
- there are separate dockerfiles and images for mutect and gatk; I ran this without touching the mutect image and only using gatk. If we update to remove the mutect image and have just one gatk image, should we also update the directory structure so mutect is nested within gatk with the rest of the gatk tools?
- snpeff annotated all variants regardless of filter = PASS status, is this expected?
- these are probably ok, but I didn't QC file output from LearnReadOrientations because I don't know what I'm looking for, and neither calc contamination or getpileupsummaries generated results (too few records?). 
- params variables are currently set up to point to the same reference genome twice (idx and mutect_idx), or at least I think it's the same. I did not edit this but wondering if these should be the same variable.
- the file names are getting really long; it might be worth going through and replacing "_" with "." so we can use `simpleName` to keep them short
