### PR TITLE
cpu variable

### DIFF
--- a/tools/bwa/bwamem2.nf
+++ b/tools/bwa/bwamem2.nf
@@ -21,7 +21,7 @@ process BWAMEM2 {
     // BWA-MEM2 alignment command
     script:
     """
-    bwa-mem2 mem -K 100000000 -t 8 -Y -M -R "@RG\\tID:${params.id}\\tLB:no_library\\tPL:illumina\\tPU:none\\tSM:${sample_id}" ${params.idx} ${reads[0]} ${reads[1]} | samtools view -Sb -@ 4 > ${sample_id}.bam
+    bwa-mem2 mem -K 100000000 -t ${task.cpus} -Y -M -R "@RG\\tID:${params.id}\\tLB:no_library\\tPL:illumina\\tPU:none\\tSM:${sample_id}" ${params.idx} ${reads[0]} ${reads[1]} | samtools view -Sb -@ ${task.cpus} > ${sample_id}.bam
     """
 }
 


### PR DESCRIPTION
use `${task.cpus}` variable in the script block instead of hard-coding cpu use

- [x] might want to look into multithreading options for all tools used here and make sure that they are running multithread if possible. Some might be defaulting to 1 cpu even though we allocate more, since we don't set the argument in the script block